### PR TITLE
Fix hotkey instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased][unreleased]
 
 
+## [2.2.1] - 2016-01-13
+
+### Changed
+-
+Updated the [README.md](https://github.com/davidwaterston/goto-matching-bracket/blob/master/README.md) to fix the instructions for changing the hotkey used to invoke this extension. This had referenced "davidwaterston.goto-matching-bracket.findMatch" when it should be "davidwaterston.goToMatchingBracket.findMatch".
+
+
 ## [2.2.0] - 2015-10-18
 ### Added
 - This CHANGELOG.md file, formatted in the convention detailed in [Keep a CHANGELOG](http://keepachangelog.com).

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Lastly, if the _maxScanLineLength_ preference is set too low then some lines in 
 A: It can be difficult to choose a hotkey for an extension. While it's easy enough to avoid the keys assigned by Brackets itself, it's impossible to know what other extensions may be using (or even what external apps might be listening for). If you find that the default key combination (CMD-ALT-] / CTRL-ALT-]) is not suitable you can override my choice by editing your _User Key Map_ file. This is done using the _Debug_... _Open User Key Map_ menu item and adding in a new entry like this in the _overrides_ section:
 
 ```
-"Cmd-Shift-Z": "davidwaterston.goto-matching-bracket.findMatch"
+"Cmd-Shift-Z": "davidwaterston.goToMatchingBracket.findMatch"
 ```
 
 where you would replace the _Cmd-Shift-Z_ with your preferred key combination.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "title": "Go to Matching Bracket",
     "description": "Instantly locate and place the cursor on the matching bracket to the one under the cursor. Simply place the cursor on any one of {, }, (, ), [ or ] then press CTRL-ALT-RIGHT (CMD-ALT-RIGHT on Mac) or use the 'Navigate... Go to Matching Bracket' menu item to locate and place the cursor on the matching opening or closing bracket. NOTE: v2.0.0 changed the hotkey for compatibility with Brackets 1.3.",
     "homepage": "https://github.com/davidwaterston/goto-matching-bracket",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "author": "David Waterston",
     "license": "MIT",
     "i18n": [


### PR DESCRIPTION
Update the README.md to fix the instructions for changing the hotkey used to invoke this extension. This had referenced "davidwaterston.goto-matching-bracket.findMatch" when it should be "davidwaterston.goToMatchingBracket.findMatch".

Fixes #11
